### PR TITLE
Added hamcrest deps, removed redundant reactor-test deps

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,4 +1,6 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <groupId>io.scalecube</groupId>
@@ -74,7 +76,7 @@
     <!-- test scope dependencies -->
     <mockito-junit-jupiter.version>2.17.0</mockito-junit-jupiter.version>
     <junit-jupiter.version>5.2.0</junit-jupiter.version>
-    <reactor-test.version>3.1.8.RELEASE</reactor-test.version>
+    <hamcrest.version>1.3</hamcrest.version>
 
     <dockerfile.repository>scalecube/${project.artifactId}</dockerfile.repository>
     <dockerfile.maven.version>1.4.4</dockerfile.maven.version>
@@ -471,8 +473,8 @@
 
   <dependencyManagement>
     <dependencies>
+      <!-- Test -->
       <dependency>
-        <!-- Test -->
         <groupId>org.junit.jupiter</groupId>
         <artifactId>junit-jupiter-engine</artifactId>
         <version>${junit-jupiter.version}</version>
@@ -491,9 +493,15 @@
         <scope>test</scope>
       </dependency>
       <dependency>
-        <groupId>io.projectreactor</groupId>
-        <artifactId>reactor-test</artifactId>
-        <version>${reactor-test.version}</version>
+        <groupId>org.hamcrest</groupId>
+        <artifactId>hamcrest-all</artifactId>
+        <version>${hamcrest.version}</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.hamcrest</groupId>
+        <artifactId>hamcrest-core</artifactId>
+        <version>${hamcrest.version}</version>
         <scope>test</scope>
       </dependency>
     </dependencies>


### PR DESCRIPTION
Motivation:
The hamcrest we repeat in all our projects. 
reactor-test version is older than we use in our projects - and it's redundant here.