### PR TITLE
Remove `dependencyManagement` section

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,10 +71,6 @@
     <!-- check style configuration -->
     <checkstyle.config.location>google_checks.xml</checkstyle.config.location>
     <com.puppycrawl.tools.checkstyle-version>8.12</com.puppycrawl.tools.checkstyle-version>
-    <!-- test scope dependencies -->
-    <mockito-junit-jupiter.version>2.17.0</mockito-junit-jupiter.version>
-    <junit-jupiter.version>5.2.0</junit-jupiter.version>
-    <hamcrest.version>1.3</hamcrest.version>
 
     <dockerfile.repository>scalecube/${project.artifactId}</dockerfile.repository>
     <dockerfile.maven.version>1.4.6</dockerfile.maven.version>
@@ -197,13 +193,6 @@
         <plugin>
           <artifactId>maven-surefire-plugin</artifactId>
           <version>${maven-surefire-plugin.version}</version>
-          <dependencies>
-            <dependency>
-              <groupId>org.junit.jupiter</groupId>
-              <artifactId>junit-jupiter-engine</artifactId>
-              <version>${junit-jupiter.version}</version>
-            </dependency>
-          </dependencies>
         </plugin>
         <plugin>
           <groupId>org.jacoco</groupId>
@@ -465,41 +454,5 @@
       </properties>
     </profile>
   </profiles>
-
-  <dependencyManagement>
-    <dependencies>
-      <!-- Test -->
-      <dependency>
-        <groupId>org.junit.jupiter</groupId>
-        <artifactId>junit-jupiter-engine</artifactId>
-        <version>${junit-jupiter.version}</version>
-        <scope>test</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.mockito</groupId>
-        <artifactId>mockito-junit-jupiter</artifactId>
-        <version>${mockito-junit-jupiter.version}</version>
-        <scope>test</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.junit.jupiter</groupId>
-        <artifactId>junit-jupiter-params</artifactId>
-        <version>${junit-jupiter.version}</version>
-        <scope>test</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.hamcrest</groupId>
-        <artifactId>hamcrest-all</artifactId>
-        <version>${hamcrest.version}</version>
-        <scope>test</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.hamcrest</groupId>
-        <artifactId>hamcrest-core</artifactId>
-        <version>${hamcrest.version}</version>
-        <scope>test</scope>
-      </dependency>
-    </dependencies>
-  </dependencyManagement>
 
 </project>


### PR DESCRIPTION
As a result of discussion in #6 and in offline let's get rid of declaring any common dependencies in corporate pom.