### PR TITLE
Upgrade com.puppycrawl.tools:checkstyle

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
 
     <!-- check style configuration -->
     <checkstyle.config.location>google_checks.xml</checkstyle.config.location>
-    <com.puppycrawl.tools.checkstyle-version>8.18</com.puppycrawl.tools.checkstyle-version>
+    <com.puppycrawl.tools.checkstyle-version>8.20</com.puppycrawl.tools.checkstyle-version>
 
     <dockerfile.repository>scalecube/${project.artifactId}</dockerfile.repository>
     <dockerfile.maven.version>1.4.6</dockerfile.maven.version>

--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
 
     <!-- check style configuration -->
     <checkstyle.config.location>google_checks.xml</checkstyle.config.location>
-    <com.puppycrawl.tools.checkstyle-version>8.12</com.puppycrawl.tools.checkstyle-version>
+    <com.puppycrawl.tools.checkstyle-version>8.18</com.puppycrawl.tools.checkstyle-version>
 
     <dockerfile.repository>scalecube/${project.artifactId}</dockerfile.repository>
     <dockerfile.maven.version>1.4.6</dockerfile.maven.version>


### PR DESCRIPTION
CVE-2019-9658 More information
moderate severity
Upgrade com.puppycrawl.tools:checkstyle to version 8.18
https://nvd.nist.gov/vuln/detail/CVE-2019-9658
Vulnerable versions: < 8.18
Patched version: 8.18
Checkstyle prior to 8.18 loads external DTDs by default, which can potentially lead to denial of service attacks or the leaking of confidential information.