### PR TITLE
Reverted puppy-crawl to 14

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
 
     <!-- check style configuration -->
     <checkstyle.config.location>google_checks.xml</checkstyle.config.location>
-    <com.puppycrawl.tools.checkstyle-version>8.20</com.puppycrawl.tools.checkstyle-version>
+    <com.puppycrawl.tools.checkstyle-version>8.14</com.puppycrawl.tools.checkstyle-version>
 
     <dockerfile.repository>scalecube/${project.artifactId}</dockerfile.repository>
     <dockerfile.maven.version>1.4.6</dockerfile.maven.version>


### PR DESCRIPTION
Subj.

Has implicit connection with migrating scalecube projects on java 11. We need release parent jdk scalecube on jdk 11 and don't break current child project's checkstyle.